### PR TITLE
Adding parameter to select fields in a query

### DIFF
--- a/main.go
+++ b/main.go
@@ -104,6 +104,10 @@ func main() {
 					Name:  "endbefore, eb",
 					Usage: "Results end before document `ID`",
 				},
+				cli.StringSliceFlag{
+					Name:  "select",
+					Usage: "Return only `FIELD_PATH` fields in result. Parameter can be given multiple times",
+				},
 			},
 		},
 	}

--- a/query.go
+++ b/query.go
@@ -153,7 +153,6 @@ func queryCommandAction(c *cli.Context) error {
 	}
 
 	if selectFields != nil {
-		fmt.Println(selectFields)
 		query = query.Select(selectFields...)
 	}
 

--- a/query.go
+++ b/query.go
@@ -89,6 +89,7 @@ func queryCommandAction(c *cli.Context) error {
 	startAfter := c.String("startafter")
 	endAt := c.String("endat")
 	endBefore := c.String("endbefore")
+	selectFields := c.StringSlice("select")
 
 	client, err := createClient(credentials)
 	if err != nil {
@@ -149,6 +150,11 @@ func queryCommandAction(c *cli.Context) error {
 			return cli.NewExitError(fmt.Sprintf("Failed to get '%s' within the collection", endBefore), 83)
 		}
 		query = query.EndBefore(docsnap)
+	}
+
+	if selectFields != nil {
+		fmt.Println(selectFields)
+		query = query.Select(selectFields...)
 	}
 
 	documentIterator := query.Documents(context.Background())


### PR DESCRIPTION
The firestore api allows to only get certain fields in a query via a 'select' parameter. This can be used to reduce the size of the returned messages. This commit adds the select parameter to the query command by which several fieldpathes can be given.

Example: fuego query Collection --select FieldA --select FieldB