### PR TITLE
Optional batched query requests

### DIFF
--- a/main.go
+++ b/main.go
@@ -108,6 +108,11 @@ func main() {
 					Name:  "select",
 					Usage: "Return only `FIELD_PATH` fields in result. Parameter can be given multiple times",
 				},
+				cli.IntFlag{
+					Name:  "batch, b",
+					Usage: "Will fetch documents in several requests with at most `BATCH` documents per request to prevent timeouts.",
+					Value: 100,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
If a resultset is too big Firestore will time out after 30s. This is a desirable feature when querying from a user driven application. But when developing/debugging a bigger dataset may be needed. To facilitate this we must make several queries and use paging:

https://firebase.google.com/docs/firestore/query-data/query-cursors

The `--batch` parameter allows low level control of how many documents will be returned by each request. The existing `--limit` parameter still ensures a upper bound of how many documents are returned over all

Tested locally with and without orderby parameter. I see no really effective way to unittest this change.

Thanks for your time and effort in building this tool!