### PR TITLE
Add projectid flag instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,11 @@ fuego get mycollection mydocumentid
 
 If you need to use fuego with the firestore emulator instead of a real firestore
 database, set the FIRESTORE_EMULATOR_HOST environment variable to something
-appropriate (usually, localhost:8080). if no project is set, fuego will default
-to 'default'.
+appropriate (usually, localhost:8080).
+
+### Firebase project ID
+
+Set the project ID with `-projectid NAME`. Defaults to 'default'.
 
 ### List collections
 


### PR DESCRIPTION
At first I tried out the client with the emulator running, and it seemed to work fine but I couldn't see the changes in the emulator UI. Of course I had to set the projectid flag but I had to read the source to understand how to do it. I think a quick README comment could be helpful to future users.

As an aside, I would have expected fuego to read my local `.firebaserc` file to get the project id. If you think that'd be a valuable addition to your project I'd be willing to work on a patch. lmk.