### PR TITLE
Adds support for using document paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,12 @@ fuego get people Rv7ZfnLQWprdXuulqMdf
 You can also replace an existing document:
 
 ```
-fuego set people Rv7ZfnLQWprdXuulqMdf '{"name": "sergio", "age": 42}' # It's my birthday!
+fuego set people/Rv7ZfnLQWprdXuulqMdf '{"name": "sergio", "age": 42}' # It's my birthday!
 ```
+
+Note: we can either use the arguments ```collection-path document-id
+json-data``` or ```document-path json-data```. This is also the case for the
+delete command.
 
 In both ```add``` and ```set``` commands, the document argument can be either a
 json string (if it starts with the character '{') or a path to a json file, i.e.:
@@ -120,7 +124,7 @@ fuego add animals ./dog.json
 To delete a document:
 
 ```sh
-fuego delete people Rv7ZfnLQWprdXuulqMdf
+fuego delete people/Rv7ZfnLQWprdXuulqMdf
 ```
 
 note: this won't delete any subcollection under the document.

--- a/delete.go
+++ b/delete.go
@@ -1,21 +1,36 @@
 package main
 
 import (
+	firestore "cloud.google.com/go/firestore"
 	"context"
 	"fmt"
 	"github.com/urfave/cli"
 )
 
 func deleteCommandAction(c *cli.Context) error {
-	collectionPath := c.Args().First()
-	id := c.Args().Get(1)
+	argsLength := len(c.Args())
+
+	if argsLength < 1 || argsLength > 2 {
+		return cli.NewExitError("Wrong number of arguments", 82)
+	}
+
 	client, err := createClient(credentials)
 	if err != nil {
 		return cliClientError(err)
 	}
 
-	collectionRef := client.Collection(collectionPath)
-	documentRef := collectionRef.Doc(id)
+	var documentRef *firestore.DocumentRef
+
+	if argsLength == 2 {
+		collectionPath := c.Args().First()
+		id := c.Args().Get(1)
+		collectionRef := client.Collection(collectionPath)
+		documentRef = collectionRef.Doc(id)
+	} else {
+		documentPath := c.Args().First()
+		documentRef = client.Doc(documentPath)
+	}
+
 	res, err := documentRef.Delete(context.Background())
 	if err != nil {
 		return cli.NewExitError(fmt.Sprintf("Failed to delete data. \n%v", res), 82)

--- a/get.go
+++ b/get.go
@@ -9,11 +9,17 @@ import (
 
 func getData(
 	client *firestore.Client,
-	collection string,
+	collectionPath string,
+	documentPath string,
 	id string) (string, error) {
 
-	collectionRef := client.Collection(collection)
-	documentRef := collectionRef.Doc(id)
+	var documentRef *firestore.DocumentRef
+	if collectionPath != "" {
+		collectionRef := client.Collection(collectionPath)
+		documentRef = collectionRef.Doc(id)
+	} else {
+		documentRef = client.Doc(documentPath)
+	}
 	docsnap, err := documentRef.Get(context.Background())
 	if err != nil {
 		return "", err
@@ -26,17 +32,34 @@ func getData(
 }
 
 func getCommandAction(c *cli.Context) error {
-	collectionPath := c.Args().First()
-	id := c.Args().Get(1)
+	argsLength := len(c.Args())
+
+	if argsLength < 1 || argsLength > 2 {
+		return cli.NewExitError("Wrong number of arguments", 82)
+	}
+
+	var collectionPath, documentPath, id string
+
+	if argsLength == 2 {
+		collectionPath = c.Args().First()
+		id = c.Args().Get(1)
+	} else {
+		documentPath = c.Args().First()
+	}
+
 	client, err := createClient(credentials)
 	if err != nil {
 		return cliClientError(err)
 	}
-	data, err := getData(client, collectionPath, id)
+
+	data, err := getData(client, collectionPath, documentPath, id)
+
 	if err != nil {
 		return cli.NewExitError(fmt.Sprintf("Failed to get data. \n%v", err), 82)
 	}
+
 	fmt.Fprintf(c.App.Writer, "%v\n", data)
+
 	defer client.Close()
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ func main() {
 			Name:      "set",
 			Aliases:   []string{"s"},
 			Usage:     "Set the contents of a document",
-			ArgsUsage: "collection-path document-id json-document",
+			ArgsUsage: "[collection-path document-id json-document | document-path json-document]",
 			Action:    setCommandAction,
 			Flags: append(
 				writingFlags,
@@ -76,14 +76,14 @@ func main() {
 			Name:      "get",
 			Aliases:   []string{"g"},
 			Usage:     "Get a document from a collection",
-			ArgsUsage: "collection-path document-id",
+			ArgsUsage: "[collection-path document-id | document-path]",
 			Action:    getCommandAction,
 		},
 		{
 			Name:      "delete",
 			Aliases:   []string{"d"},
 			Usage:     "Delete a document from a collection",
-			ArgsUsage: "collection-path document-id",
+			ArgsUsage: "[collection-path document-id | document-path]",
 			Action:    deleteCommandAction,
 		},
 		{

--- a/tests/tests
+++ b/tests/tests
@@ -42,6 +42,10 @@ testAddSetReadDeleteDocument() {
     result=$(../fuego get ${TEST_COLLECTION} ${id} | jq ".level1")
     assertEquals "Failed to read set value" "\"${expectedValue}\"" "${result}"
 
+		# Also test reading using document-path
+    result=$(../fuego get ${TEST_COLLECTION}/${id} | jq ".level1")
+    assertEquals "Failed to read set value" "\"${expectedValue}\"" "${result}"
+
 		# And deleting...
 		../fuego delete ${TEST_COLLECTION} ${id}
 		assertFalse "Should not have read deleted value" "../fuego get ${TEST_COLLECTION} ${id}"
@@ -51,8 +55,8 @@ testUpdatingDocument(){
     # add a new document
     id=$(../fuego add ${TEST_COLLECTION} "{\"level1\": \"value\"}") || fail "Failed to add document"
 
-    # add a new field
-    ../fuego set --merge ${TEST_COLLECTION} ${id} "{\"version\": 2}" || fail "Failed to add document"
+    # add a new field using document path
+    ../fuego set --merge ${TEST_COLLECTION}/${id} "{\"version\": 2}" || fail "Failed to add document"
     result=$(../fuego get ${TEST_COLLECTION} ${id} | jq .)
     expectedValue=$(echo {\"level1\": \"value\", \"version\": 2} | jq .)
     assertEquals "Failed to update new fields" "${expectedValue}" "${result}"
@@ -212,19 +216,34 @@ testOrderAndPagination(){
     result=$(../fuego query --limit 1 --orderby 'level1.level2' --orderdir DESC --startat ${r2} ${TEST_COLLECTION}  | jq ".[0].ID")
     assertEquals "startat failed" "$result" "\"$r2\""
 
+		# Start at using document path
+		result=$(../fuego query --limit 1 --orderby 'level1.level2' --orderdir DESC --startat ${TEST_COLLECTION}/${r2} ${TEST_COLLECTION}  | jq ".[0].ID")
+    assertEquals "startat failed" "$result" "\"$r2\""
+
     # Start after
-    result=$(../fuego query --limit 1 --orderby 'level1.level2' --orderdir DESC --startafter ${r2} ${TEST_COLLECTION}  | jq ".[0].ID")
+		result=$(../fuego query --limit 1 --orderby 'level1.level2' --orderdir DESC --startafter ${r2} ${TEST_COLLECTION}  | jq ".[0].ID")
+    assertEquals "startat failed" "$result" "\"$r1\""
+
+		# Start after using document path
+    result=$(../fuego query --limit 1 --orderby 'level1.level2' --orderdir DESC --startafter ${TEST_COLLECTION}/${r2} ${TEST_COLLECTION}  | jq ".[0].ID")
     assertEquals "startat failed" "$result" "\"$r1\""
 
     # End at
     result=$(../fuego query --orderby 'level1.level2' --orderdir DESC --endat ${r2} ${TEST_COLLECTION}  | jq "length")
     assertEquals "endat failed" "2" "$result"
 
+		# End at using document path
+    result=$(../fuego query --orderby 'level1.level2' --orderdir DESC --endat ${TEST_COLLECTION}/${r2} ${TEST_COLLECTION}  | jq "length")
+    assertEquals "endat failed" "2" "$result"
+
     # End before
     result=$(../fuego query --orderby 'level1.level2' --orderdir DESC --endbefore ${r2} ${TEST_COLLECTION}  | jq "length")
     assertEquals "endbefore failed" "1" "$result"
-}
 
+		# End before using document path
+    result=$(../fuego query --orderby 'level1.level2' --orderdir DESC --endbefore ${TEST_COLLECTION}/${r2} ${TEST_COLLECTION}  | jq "length")
+    assertEquals "endbefore failed" "1" "$result"
+}
 
 testParsingFieldPaths(){
     r1=$(../fuego add ${TEST_COLLECTION} "{\"le.vel1\": {\" level2 \": 1, \"a\": 1}}")


### PR DESCRIPTION
Currently, we are always passing document IDs to the different commands. I'm adding support for document paths, without breaking existing scripts.

1. in "get", "set" and "delete" commands we can still pass a collection-path and a document-id, but we can now pass just a document-path (i.e. fuego delete people sergio OR fuego delete people/sergio). 
2. in the query command, the startAt, startAfter, endAt, endBefore, we can still pass a document id (which contains no "/") or a document path. in the first case, it is assumed it is a document within the collection referenced in the arguments.