### PR TITLE
Feat/support copying 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@
       - [Selecting specific fields](#selecting-specific-fields)
       - [Pagination of query results](#pagination-of-query-results)
       - [Group queries](#group-queries)
+    - [Copying](#copying)
+      - [Copying collection](#copying-collection)
+      - [Copying document](#copying-document)
+      - [Cross projects copying](#cross-projects-copying)
   - [Contributing](#contributing)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -346,6 +350,40 @@ You can make [group
 queries](https://firebase.google.com/docs/firestore/query-data/queries) by using
 the -g flag. 
 
+
+### Copying
+Basic usage
+```sh
+fuego copy source target
+```
+#### Copying collection
+We can copy a collection and its sub collections
+```sh
+fuego copy countries/france/cities countries/germany/cities 
+```
+By default, existing documents in target collection will be skipped. If you want to overwrite the existing document, just use --overwrite
+```sh
+fuego copy countries/france/cities countries/germany/cities --overwrite
+```
+Also, use --merge let us can use merging mode to overwrite the existing documents
+```sh
+fuego copy countries/france/cities countries/germany/cities --overwrite --merge
+```
+
+#### Copying document
+We can copy a document and its sub collections.
+```sh
+fuego copy countries/france countries/germany
+```
+Parameters --merge and --overwrite can also be used to specify the copying behavior.
+
+#### Cross projects copying
+We may have firestore in different Google projects. We can specify the source project credential by using `--src-credentials` (or `-sc`) and target project credential by using `--dest-credentials` (or `-dc`).
+The default value of the `--src-credentials` and `--dest-credentials` is our current working project.
+```sh
+fuego copy countries/france countries/germany --src-credentials ./project-a-key.json --dest-credentials ./project-b-key.json --overwrite --merge
+fuego copy countries/france/cities countries/germany/cities --src-credentials ./project-a-key.json --dest-credentials ./project-b-key.json
+```
 ## Contributing
 
 See the [HACKING](HACKING.md) file for some guidance on how to contribute.

--- a/README.md
+++ b/README.md
@@ -384,6 +384,13 @@ The default value of the `--src-credentials` and `--dest-credentials` is our cur
 fuego copy countries/france countries/germany --src-credentials ./project-a-key.json --dest-credentials ./project-b-key.json --overwrite --merge
 fuego copy countries/france/cities countries/germany/cities --src-credentials ./project-a-key.json --dest-credentials ./project-b-key.json
 ```
+We may also have a credential that has access to different projects. We can specify the source project ID by `--src-projectid` (or `-sp`) and target project credential by using `--dest-projectid` (or `-dp`).
+The default value of the `--src-prjectid` and `--dest-prjectid` is the ID of our current working project.
+```sh
+fuego copy countries/france countries/germany --src-projectid project-a --dest-projectid project-b --overwrite --merge
+fuego copy countries/france/cities countries/germany/cities --dest-projectid prject-c
+```
+
 ## Contributing
 
 See the [HACKING](HACKING.md) file for some guidance on how to contribute.

--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ By default, existing documents in target collection will be skipped. If you want
 ```sh
 fuego copy countries/france/cities countries/germany/cities --overwrite
 ```
-Also, use --merge let us can use merging mode to overwrite the existing documents
+Also, using flag --merge let us can use merging mode to overwrite the existing documents
 ```sh
 fuego copy countries/france/cities countries/germany/cities --overwrite --merge
 ```
@@ -384,7 +384,7 @@ The default value of the `--src-credentials` and `--dest-credentials` is our cur
 fuego copy countries/france countries/germany --src-credentials ./project-a-key.json --dest-credentials ./project-b-key.json --overwrite --merge
 fuego copy countries/france/cities countries/germany/cities --src-credentials ./project-a-key.json --dest-credentials ./project-b-key.json
 ```
-We may also have a credential that has access to different projects. We can specify the source project ID by `--src-projectid` (or `-sp`) and target project credential by using `--dest-projectid` (or `-dp`).
+We may also have a credential that has access to different projects. We can specify the source project ID by `--src-projectid` (or `-sp`) and target project ID by using `--dest-projectid` (or `-dp`).
 The default value of the `--src-prjectid` and `--dest-prjectid` is the ID of our current working project.
 ```sh
 fuego copy countries/france countries/germany --src-projectid project-a --dest-projectid project-b --overwrite --merge

--- a/client.go
+++ b/client.go
@@ -41,7 +41,43 @@ func createClient(credentials string) (*firestore.Client, error) {
 	}
 }
 
+func createClientWithProjectId(credentials string, projectId string) (*firestore.Client, error) {
+	var err error
+	var firebaseApp *firebase.App
+	if os.Getenv("FIRESTORE_EMULATOR_HOST") != "" {
+		if projectId == "" {
+			projectId = "default"
+		}
+		client, err := firestore.NewClient(context.Background(), projectId)
+		return client, err
+	} else if credentials != "" {
+		sa := option.WithCredentialsFile(credentials)
+		config := getConfigWithProjectId(projectId)
+		firebaseApp, err = firebase.NewApp(context.Background(), config, sa)
+		if err != nil {
+			return nil, err
+		}
+		return firebaseApp.Firestore(context.Background())
+	} else {
+		// This will use GOOGLE_APPLICATION_CREDENTIALS
+		config := getConfigWithProjectId(projectId)
+		firebaseApp, err = firebase.NewApp(context.Background(), config)
+		if err != nil {
+			return nil, err
+		}
+		return firebaseApp.Firestore(context.Background())
+	}
+}
+
 func getConfig() *firebase.Config {
+	config := firebase.Config{}
+	if projectId != "" {
+		config.ProjectID = projectId
+	}
+	return &config
+}
+
+func getConfigWithProjectId(projectId string) *firebase.Config {
 	config := firebase.Config{}
 	if projectId != "" {
 		config.ProjectID = projectId

--- a/client.go
+++ b/client.go
@@ -14,31 +14,7 @@ import (
 // default projectid if none has been set.
 
 func createClient(credentials string) (*firestore.Client, error) {
-	var err error
-	var firebaseApp *firebase.App
-	if os.Getenv("FIRESTORE_EMULATOR_HOST") != "" {
-		if projectId == "" {
-			projectId = "default"
-		}
-		client, err := firestore.NewClient(context.Background(), projectId)
-		return client, err
-	} else if credentials != "" {
-		sa := option.WithCredentialsFile(credentials)
-		config := getConfig()
-		firebaseApp, err = firebase.NewApp(context.Background(), config, sa)
-		if err != nil {
-			return nil, err
-		}
-		return firebaseApp.Firestore(context.Background())
-	} else {
-		// This will use GOOGLE_APPLICATION_CREDENTIALS
-		config := getConfig()
-		firebaseApp, err = firebase.NewApp(context.Background(), config)
-		if err != nil {
-			return nil, err
-		}
-		return firebaseApp.Firestore(context.Background())
-	}
+	return createClientWithProjectId(credentials, projectId)
 }
 
 func createClientWithProjectId(credentials string, projectId string) (*firestore.Client, error) {
@@ -67,14 +43,6 @@ func createClientWithProjectId(credentials string, projectId string) (*firestore
 		}
 		return firebaseApp.Firestore(context.Background())
 	}
-}
-
-func getConfig() *firebase.Config {
-	config := firebase.Config{}
-	if projectId != "" {
-		config.ProjectID = projectId
-	}
-	return &config
 }
 
 func getConfigWithProjectId(projectId string) *firebase.Config {

--- a/copy.go
+++ b/copy.go
@@ -51,12 +51,23 @@ func copyCommandAction(c *cli.Context) error {
 	sc := c.String("src-credentials")
 	dc := c.String("dest-credentials")
 
+	sp := c.String("src-projectid")
+	dp := c.String("dest-projectid")
+
 	if sc == "" {
 		sc = credentials
 	}
 
 	if dc == "" {
 		dc = credentials
+	}
+
+	if sp == "" {
+		sp = projectId
+	}
+
+	if dp == "" {
+		dp = projectId
 	}
 
 	option := CopyOption{
@@ -71,12 +82,12 @@ func copyCommandAction(c *cli.Context) error {
 		return cli.NewExitError(fmt.Sprintf("Can't copy from %s to %s", sType.String(), tType.String()), 87)
 	}
 
-	sourceClient, err := createClient(sc)
+	sourceClient, err := createClientWithProjectId(sc, sp)
 	if err != nil {
 		return cliClientError(err)
 	}
 
-	targetClient, err := createClient(dc)
+	targetClient, err := createClientWithProjectId(dc, dp)
 	if err != nil {
 		return cliClientError(err)
 	}

--- a/copy.go
+++ b/copy.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"cloud.google.com/go/firestore"
+	"context"
+	"fmt"
+	"github.com/urfave/cli"
+	"google.golang.org/api/iterator"
+	"log"
+	"strings"
+	"sync"
+)
+
+type PathType int
+
+const (
+	DocumentPath   PathType = 0
+	CollectionPath PathType = 1
+)
+
+func (p PathType) String() string {
+	switch p {
+	case DocumentPath: return "Document"
+	case CollectionPath: return "Collection"
+	default:         return "UNKNOWN"
+	}
+}
+
+type CopyOption struct {
+	merge bool
+	overwrite bool
+}
+
+func pathType(p string) PathType {
+	return PathType(len(strings.Split(strings.Trim(p, "/"), "/")) % 2)
+}
+
+func copyCommandAction(c *cli.Context) error {
+	argsLength := len(c.Args())
+
+	if argsLength != 2 {
+		return cli.NewExitError("Wrong number of arguments", 85)
+	}
+
+	sourceCollectionOrDocumentPath := strings.Trim(c.Args().Get(0), "/")
+	targetCollectionOrDocumentPath := strings.Trim(c.Args().Get(1), "/")
+
+	merge := c.Bool("merge")
+	overwrite := c.Bool("overwrite")
+
+	sc := c.String("src-credentials")
+	dc := c.String("dest-credentials")
+
+	if sc == "" {
+		sc = credentials
+	}
+
+	if dc == "" {
+		dc = credentials
+	}
+
+	option := CopyOption{
+		merge:    merge,
+		overwrite: overwrite,
+	}
+
+	sType := pathType(sourceCollectionOrDocumentPath)
+	tType := pathType(targetCollectionOrDocumentPath)
+
+	if sType != tType {
+		return cli.NewExitError(fmt.Sprintf("Can't copy from %s to %s", sType.String(), tType.String()), 87)
+	}
+
+	sourceClient, err := createClient(sc)
+	if err != nil {
+		return cliClientError(err)
+	}
+
+	targetClient, err := createClient(dc)
+	if err != nil {
+		return cliClientError(err)
+	}
+
+	if sType == CollectionPath {
+		log.Println("copying collection")
+		copyCollection(
+			sourceClient.Collection(sourceCollectionOrDocumentPath),
+			targetClient.Collection(targetCollectionOrDocumentPath),
+			option,
+			)
+	}
+
+	if sType == DocumentPath {
+		log.Println("copying document")
+		copyDocument(
+			sourceClient.Doc(sourceCollectionOrDocumentPath),
+			targetClient.Doc(targetCollectionOrDocumentPath),
+			option,
+			)
+	}
+
+	log.Println("Done")
+
+	return nil
+}
+
+func copyDocument(source, target *firestore.DocumentRef, option CopyOption)  {
+	targetDoc, err := target.Get(context.Background())
+
+	if targetDoc == nil {
+		if err != nil {
+			log.Fatalf("get document %s error: %s\n", target.Path, err)
+			return
+		}
+		return
+	}
+
+	if targetDoc.Exists() && !option.overwrite {
+		log.Fatalf("skipped document %s, because it already exists. use --override to override \n", target.Path)
+		return
+	}
+
+	sourceDoc, err := source.Get(context.Background())
+
+	if sourceDoc == nil {
+		if err != nil {
+			log.Fatalf("get document %s error: %s\n", source.Path, err)
+			return
+		}
+		return
+	}
+
+	var options []firestore.SetOption
+	if option.merge {
+		options = append(options, firestore.MergeAll)
+	}
+
+	if sourceDoc.Exists() {
+		_, err := target.Set(context.Background(), sourceDoc.Data(), options...)
+		if err != nil {
+			log.Fatalf("copy document %s to %s error: %s\n", source.Path, target.Path, err)
+			return
+		}
+	}
+
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	collections := source.Collections(context.Background())
+
+	for {
+		next, err := collections.Next()
+		if err == iterator.Done {
+			return
+		}
+		if err != nil {
+			log.Fatal(err)
+			return
+		}
+
+		wg.Add(1)
+		go func(s, t *firestore.CollectionRef, wwg *sync.WaitGroup) {
+			defer wwg.Done()
+			copyCollection(s, t, option)
+		}(next, target.Collection(next.ID), &wg)
+	}
+}
+
+func copyCollection(source, target *firestore.CollectionRef, option CopyOption)  {
+	refs := source.DocumentRefs(context.Background())
+	var wg sync.WaitGroup
+	defer wg.Wait()
+	for {
+		next, err := refs.Next()
+		if err == iterator.Done {
+			return
+		}
+		if err != nil {
+			log.Fatal(err)
+			return
+		}
+		wg.Add(1)
+		go func(s, t *firestore.DocumentRef, wwg *sync.WaitGroup) {
+			defer wwg.Done()
+			copyDocument(s, t, option)
+		}(next, target.Doc(next.ID), &wg)
+	}
+}

--- a/copy.go
+++ b/copy.go
@@ -8,7 +8,8 @@ import (
 	"google.golang.org/api/iterator"
 	"log"
 	"strings"
-	"sync"
+	"sync/atomic"
+	"time"
 )
 
 type PathType int
@@ -116,84 +117,274 @@ func copyCommandAction(c *cli.Context) error {
 }
 
 func copyDocument(source, target *firestore.DocumentRef, option CopyOption)  {
-	targetDoc, err := target.Get(context.Background())
+	client := NewCopyClient(200, option)
 
-	if targetDoc == nil {
-		if err != nil {
-			log.Fatalf("get document %s error: %s\n", target.Path, err)
-			return
-		}
-		return
-	}
-
-	if targetDoc.Exists() && !option.overwrite {
-		log.Fatalf("skipped document %s, because it already exists. use --override to override \n", target.Path)
-		return
-	}
-
-	sourceDoc, err := source.Get(context.Background())
-
-	if sourceDoc == nil {
-		if err != nil {
-			log.Fatalf("get document %s error: %s\n", source.Path, err)
-			return
-		}
-		return
-	}
-
-	var options []firestore.SetOption
-	if option.merge {
-		options = append(options, firestore.MergeAll)
-	}
-
-	if sourceDoc.Exists() {
-		_, err := target.Set(context.Background(), sourceDoc.Data(), options...)
-		if err != nil {
-			log.Fatalf("copy document %s to %s error: %s\n", source.Path, target.Path, err)
-			return
-		}
-	}
-
-	var wg sync.WaitGroup
-	defer wg.Wait()
-
-	collections := source.Collections(context.Background())
-
-	for {
-		next, err := collections.Next()
-		if err == iterator.Done {
-			return
-		}
-		if err != nil {
-			log.Fatal(err)
-			return
-		}
-
-		wg.Add(1)
-		go func(s, t *firestore.CollectionRef, wwg *sync.WaitGroup) {
-			defer wwg.Done()
-			copyCollection(s, t, option)
-		}(next, target.Collection(next.ID), &wg)
-	}
+	client.Run(
+		NewDocumentCopyJob(source, target),
+		NewCollectionIterationJob(source, target),
+		)
 }
 
 func copyCollection(source, target *firestore.CollectionRef, option CopyOption)  {
-	refs := source.DocumentRefs(context.Background())
-	var wg sync.WaitGroup
-	defer wg.Wait()
-	for {
-		next, err := refs.Next()
+	client := NewCopyClient(200, option)
+
+	client.Run(NewDocumentIterationJob(source, target))
+}
+
+type CopyClient struct {
+	jobQueue []CopyJob
+	workerQueue   []chan CopyJob
+	jobChannel    chan CopyJob
+	workerChannel chan chan CopyJob
+	WorkerCount int
+	Option CopyOption
+}
+
+func NewCopyClient(workerCount int, option CopyOption) CopyClient {
+	return CopyClient{
+		jobChannel:    make(chan CopyJob),
+		workerChannel: make(chan chan CopyJob),
+		WorkerCount:   workerCount,
+		Option:        option,
+	}
+}
+
+func (client *CopyClient) Run(seeds... CopyJob)  {
+	out := make(chan []CopyJob)
+
+	go func() {
+		// submit initial jobs
+		for _, j := range seeds {
+			client.submitJob(j)
+		}
+
+		for {
+			// read jobs from workers
+			jobs := <-out
+			for _, j := range jobs {
+				client.submitJob(j)
+			}
+		}
+	}()
+
+	// create works to handle jobs
+	client.createWorkers(out)
+
+	// match workers with jobs
+	done := client.scheduleJobs()
+
+	<- done
+}
+
+func (client *CopyClient) submitJob(job CopyJob)  {
+	client.jobChannel <- job
+}
+
+func (client *CopyClient) workerReady(w chan CopyJob)  {
+	client.workerChannel <- w
+}
+
+func (client *CopyClient) workerInput() chan CopyJob  {
+	return make(chan CopyJob)
+}
+
+func (client *CopyClient) createWorkers(workerOutput chan []CopyJob) {
+	for i:=0; i < client.WorkerCount; i++ {
+		in := client.workerInput()
+		go func(in chan CopyJob) {
+			for {
+				client.workerReady(in)
+				j := <-in
+				w := CopyWorker{
+					Overwrite: client.Option.overwrite,
+					Merge:     client.Option.merge,
+				}
+				jobs, err := w.handleJob(j)
+				if err != nil {
+					continue
+				}
+				workerOutput <- jobs
+			}
+		}(in)
+	}
+}
+
+func (client *CopyClient) scheduleJobs() <- chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		j := <- client.jobChannel
+		client.jobQueue = append(client.jobQueue, j)
+
+		for {
+			var activeJob CopyJob
+			var activeWorker chan CopyJob
+
+			if len(client.jobQueue) > 0 && len(client.workerQueue) > 0 {
+				activeJob = client.jobQueue[0]
+				activeWorker = client.workerQueue[0]
+			}
+
+			select {
+			case jj := <- client.jobChannel:
+				client.jobQueue = append(client.jobQueue, jj)
+			case w := <- client.workerChannel:
+				client.workerQueue = append(client.workerQueue, w)
+			case activeWorker <- activeJob:
+				client.jobQueue = client.jobQueue[1:]
+				client.workerQueue = client.workerQueue[1:]
+			case <- time.After(time.Second * 2):
+				// no more jobs
+				if len(client.jobQueue) == 0 && len(client.workerQueue) == client.WorkerCount {
+					done <- struct{}{}
+					return
+				}
+			}
+		}
+	}()
+	return done
+}
+
+var ops int32
+
+type CopyWorker struct {
+	Overwrite bool
+	Merge bool
+}
+
+func (w *CopyWorker) handleJob(j CopyJob) ([]CopyJob, error)  {
+	var result []CopyJob
+
+	if j.name == "iterateCollection" {
+		return w.handleCollectionIterationJob(j)
+	}
+
+	if j.name == "iterateDocument" {
+		return w.handleDocumentIterationJob(j)
+	}
+
+	if j.name == "copyDocument" {
+		return w.handleCopyDocumentJob(j)
+	}
+
+	return result, nil
+}
+
+func (w *CopyWorker) handleCollectionIterationJob(j CopyJob) ([]CopyJob, error) {
+	var result []CopyJob
+
+	if next, err := j.collectionIterator.Next(); err != nil {
 		if err == iterator.Done {
-			return
+			return result, nil
 		}
+		return result, err
+	} else {
+		result = append(result,
+			j,
+			NewDocumentIterationJob(next, j.targetDocumentRef.Collection(next.ID)),
+		)
+		return result, nil
+	}
+}
+
+func (w *CopyWorker) handleDocumentIterationJob(j CopyJob) ([]CopyJob, error) {
+	var result []CopyJob
+
+	if next, err := j.documentRefIterator.Next(); err != nil {
+		if err == iterator.Done {
+			return result, nil
+		}
+		return result, err
+	} else {
+		result = append(result,
+			j,
+			NewCollectionIterationJob(next, j.targetCollectionRef.Doc(next.ID)),
+			NewDocumentCopyJob(next, j.targetCollectionRef.Doc(next.ID)),
+		)
+		return result, nil
+	}
+}
+
+func (w *CopyWorker) handleCopyDocumentJob(j CopyJob) ([]CopyJob, error) {
+	var result []CopyJob
+
+	targetDoc, err := j.targetDocumentRef.Get(context.Background())
+
+	if targetDoc == nil {
 		if err != nil {
-			log.Fatal(err)
-			return
+			log.Printf("get document %s error: %s\n", j.targetDocumentRef.Path, err)
+			return result, err
 		}
-		wg.Add(1)
-		go func(s, t *firestore.DocumentRef, wwg *sync.WaitGroup) {
-			defer wwg.Done()
-			copyDocument(s, t, option)
-		}(next, target.Doc(next.ID), &wg)
+		return result, nil
+	}
+
+	if targetDoc.Exists() && !w.Overwrite {
+		log.Printf("skipped document %s, because it already exists. use --overwrite to overwrite \n", j.targetDocumentRef.Path)
+		return result, nil
+	}
+
+	sourceDoc, err := j.documentRef.Get(context.Background())
+
+	if sourceDoc == nil {
+		if err != nil {
+			log.Printf("get document %s error: %s\n", j.documentRef.Path, err)
+			return result, err
+		}
+		return result, nil
+	}
+
+	var options []firestore.SetOption
+	if w.Merge {
+		options = append(options, firestore.MergeAll)
+	}
+
+	atomic.AddInt32(&ops, 1)
+
+	if sourceDoc.Exists() {
+		log.Printf("set document: %d, %s \n", ops, j.targetDocumentRef.Path)
+		_, err = j.targetDocumentRef.Set(context.Background(), sourceDoc.Data(), options...)
+		if err != nil {
+			log.Printf("copy document %s to %s error: %s\n", j.documentRef.Path, j.targetDocumentRef.Path, err)
+			return result, err
+		}
+	}
+
+	return result, nil
+}
+
+type CopyJob struct {
+	// iterateCollection iterateDocument copyDocument
+	name string
+
+	documentRef *firestore.DocumentRef
+
+	collectionIterator *firestore.CollectionIterator
+	targetDocumentRef *firestore.DocumentRef
+
+	documentRefIterator *firestore.DocumentRefIterator
+	targetCollectionRef *firestore.CollectionRef
+}
+
+func NewCollectionIterationJob(documentRef *firestore.DocumentRef, targetDocumentRef *firestore.DocumentRef) CopyJob {
+	return CopyJob{
+		name:                "iterateCollection",
+		collectionIterator:  documentRef.Collections(context.Background()),
+		targetDocumentRef:   targetDocumentRef,
+	}
+}
+
+
+func NewDocumentIterationJob(collectionRef *firestore.CollectionRef, targetCollectionRef *firestore.CollectionRef) CopyJob {
+	return CopyJob{
+		name:                "iterateDocument",
+		documentRefIterator: collectionRef.DocumentRefs(context.Background()),
+		targetCollectionRef: targetCollectionRef,
+	}
+}
+
+func NewDocumentCopyJob(documentRef *firestore.DocumentRef, targetDocumentRef *firestore.DocumentRef) CopyJob {
+	return CopyJob{
+		name:                "copyDocument",
+		documentRef:         documentRef,
+		targetDocumentRef:   targetDocumentRef,
 	}
 }

--- a/main.go
+++ b/main.go
@@ -73,6 +73,31 @@ func main() {
 			),
 		},
 		{
+			Name:      "copy",
+			Aliases:   []string{"s"},
+			Usage:     "copy collection or document",
+			ArgsUsage: "[collection-path collection-path | document-path document-path]",
+			Action:    copyCommandAction,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:        "dest-credentials, dc",
+					Usage:       "Google application target project credentials from `FILE`",
+				},
+				cli.StringFlag{
+					Name:        "src-credentials, sc",
+					Usage:       "Google application source project credentials from `FILE`",
+				},
+				cli.BoolFlag{
+					Name:  "merge",
+					Usage: "if set the set operation will do a update/patch",
+				},
+				cli.BoolFlag{
+					Name:  "overwrite",
+					Usage: "overwrite the existing collection or document",
+				},
+			},
+		},
+		{
 			Name:      "get",
 			Aliases:   []string{"g"},
 			Usage:     "Get a document from a collection",

--- a/main.go
+++ b/main.go
@@ -87,6 +87,14 @@ func main() {
 					Name:        "src-credentials, sc",
 					Usage:       "Google application source project credentials from `FILE`",
 				},
+				cli.StringFlag{
+					Name:        "dest-projectid, dp",
+					Usage:       "Target project ID",
+				},
+				cli.StringFlag{
+					Name:        "src-projectid, sp",
+					Usage:       "Source project ID",
+				},
 				cli.BoolFlag{
 					Name:  "merge",
 					Usage: "if set the set operation will do a update/patch",

--- a/tests/tests
+++ b/tests/tests
@@ -267,6 +267,45 @@ testParsingFieldPaths(){
 
 }
 
+testCopyDocumentAndCollection(){
+    # add a new document
+    id=$(../fuego add ${TEST_COLLECTION} "{\"base\": \"value\"}") || fail "Failed to add document"
+    subDocId1=$(../fuego add "${TEST_COLLECTION}/${id}/subCollection1" "{\"base\": \"sub value1\"}") || fail "Failed to add document"
+    subDocId2=$(../fuego add "${TEST_COLLECTION}/${id}/subCollection2" "{\"base\": \"sub value2\"}") || fail "Failed to add document"
+    echo ${id} ${subDocId1} ${subDocId2}
+    targetDocumentPath=${TEST_COLLECTION}/$(uuidgen)
+    targetCollectionPath=$(uuidgen)
+
+    ../fuego copy "${TEST_COLLECTION}/${id}" ${targetDocumentPath} --overwrite
+    ../fuego copy "${TEST_COLLECTION}" ${targetCollectionPath} --overwrite
+
+    # query copied document
+    result=$(../fuego get ${targetDocumentPath} | jq .)
+    expectedValue=$(echo {\"base\": \"value\"} | jq .)
+    assertEquals "Failed to copy document" "${expectedValue}" "${result}"
+
+    result=$(../fuego get "${targetDocumentPath}/subCollection1/${subDocId1}" | jq .)
+    expectedValue=$(echo {\"base\": \"sub value1\"} | jq .)
+    assertEquals "Failed to copy document" "${expectedValue}" "${result}"
+
+    result=$(../fuego get "${targetDocumentPath}/subCollection2/${subDocId2}" | jq .)
+    expectedValue=$(echo {\"base\": \"sub value2\"} | jq .)
+    assertEquals "Failed to copy document" "${expectedValue}" "${result}"
+
+    # query copied collection
+    result=$(../fuego get "${targetCollectionPath}/${id}" | jq .)
+    expectedValue=$(echo {\"base\": \"value\"} | jq .)
+    assertEquals "Failed to copy document" "${expectedValue}" "${result}"
+
+    result=$(../fuego get "${targetCollectionPath}/${id}/subCollection1/${subDocId1}" | jq .)
+    expectedValue=$(echo {\"base\": \"sub value1\"} | jq .)
+    assertEquals "Failed to copy document" "${expectedValue}" "${result}"
+
+    result=$(../fuego get "${targetCollectionPath}/${id}/subCollection2/${subDocId2}" | jq .)
+    expectedValue=$(echo {\"base\": \"sub value2\"} | jq .)
+    assertEquals "Failed to copy document" "${expectedValue}" "${result}"
+}
+
 
 # Load shUnit2.
 . ./shunit2


### PR DESCRIPTION
Support copying documents and collection.
Previously, we needed to first download the document or collection and then upload the documents to implement copying. 
Now we can just specify two different paths.