### PR TITLE
Drops getall and deleteall use of ',' to separate document ids

### DIFF
--- a/deleteall.go
+++ b/deleteall.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/urfave/cli"
-	"strings"
 )
 
 func deleteAllCommandAction(c *cli.Context) error {
@@ -17,12 +16,16 @@ func deleteAllCommandAction(c *cli.Context) error {
 
 	var collectionPath string
 	var ids []string
+
 	collectionPath = c.Args().First()
-	ids = strings.Split(c.Args()[1], ",")
+	ids = c.Args()[1:]
+
 	client, err := createClient(credentials)
+
 	if err != nil {
 		return cliClientError(err)
 	}
+
 	deletedCount := 0
 
 	for _, part := range partition(ids, maxWritesCount) {

--- a/getall.go
+++ b/getall.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/urfave/cli"
-	"strings"
 )
 
 func getDocuments(client *firestore.Client, collectionPath string, ids []string) (string, error) {
@@ -38,20 +37,23 @@ func getDocuments(client *firestore.Client, collectionPath string, ids []string)
 func getAllCommandAction(c *cli.Context) error {
 	argsLength := len(c.Args())
 
-	if argsLength < 1 {
+	if argsLength < 2 {
 		return cli.NewExitError("Wrong number of arguments", 82)
 	}
 
 	var collectionPath string
-	var id []string
+	var ids []string
+
 	collectionPath = c.Args().First()
-	id = strings.Split(c.Args()[1], ",")
+	ids = c.Args()[1:]
+
 	client, err := createClient(credentials)
+
 	if err != nil {
 		return cliClientError(err)
 	}
 
-	data, err := getDocuments(client, collectionPath, id)
+	data, err := getDocuments(client, collectionPath, ids)
 
 	if err != nil {
 		return cli.NewExitError(fmt.Sprintf("Failed to get data. \n%v", err), 82)

--- a/main.go
+++ b/main.go
@@ -80,20 +80,20 @@ func main() {
 			Action:    copyCommandAction,
 			Flags: []cli.Flag{
 				cli.StringFlag{
-					Name:        "dest-credentials, dc",
-					Usage:       "Google application target project credentials from `FILE`",
+					Name:  "dest-credentials, dc",
+					Usage: "Google application target project credentials from `FILE`",
 				},
 				cli.StringFlag{
-					Name:        "src-credentials, sc",
-					Usage:       "Google application source project credentials from `FILE`",
+					Name:  "src-credentials, sc",
+					Usage: "Google application source project credentials from `FILE`",
 				},
 				cli.StringFlag{
-					Name:        "dest-projectid, dp",
-					Usage:       "Target project ID",
+					Name:  "dest-projectid, dp",
+					Usage: "Target project ID",
 				},
 				cli.StringFlag{
-					Name:        "src-projectid, sp",
-					Usage:       "Source project ID",
+					Name:  "src-projectid, sp",
+					Usage: "Source project ID",
 				},
 				cli.BoolFlag{
 					Name:  "merge",
@@ -109,14 +109,14 @@ func main() {
 			Name:      "get",
 			Aliases:   []string{"g"},
 			Usage:     "Get a document from a collection",
-			ArgsUsage: "[collection-path document-id | document-path]",
+			ArgsUsage: "collection-path [document-id document-path]",
 			Action:    getCommandAction,
 		},
 		{
 			Name:      "getall",
 			Aliases:   []string{"ga"},
 			Usage:     "Get all document from a collection by providing ids ",
-			ArgsUsage: "[collection-path document-id1,document-id2,...]",
+			ArgsUsage: "collection-path document-id1 [document-id2 ...]",
 			Action:    getAllCommandAction,
 		},
 		{
@@ -130,7 +130,7 @@ func main() {
 			Name:      "deleteall",
 			Aliases:   []string{"da"},
 			Usage:     "Delete documents from a collection without transactional support",
-			ArgsUsage: "[collection-path document-id1,document-id2,...]",
+			ArgsUsage: "collection-path document-id1 [document-id2 ...]",
 			Action:    deleteAllCommandAction,
 		},
 		{

--- a/tests/tests
+++ b/tests/tests
@@ -58,7 +58,7 @@ testGetAllDocuments() {
     expectedValue2="string2"
     id1=$(../fuego add ${TEST_COLLECTION} "{\"level1\": \"${expectedValue1}\"}") || fail "Failed to add document"
     id2=$(../fuego add ${TEST_COLLECTION} "{\"level1\": \"${expectedValue2}\"}") || fail "Failed to add document"
-    result=$(../fuego getall ${TEST_COLLECTION} ${id1},${id2} | jq -r '.[].level1'| tr '\n' ' ')
+    result=$(../fuego getall ${TEST_COLLECTION} ${id1} ${id2} | jq -r '.[].level1'| tr '\n' ' ')
     assertEquals "Failed to read all added value" "${expectedValue1} ${expectedValue2} " "${result}"
 }
 
@@ -68,8 +68,8 @@ testDeleteAllDocuments() {
     expectedValue2="string2"
     id1=$(../fuego add ${TEST_COLLECTION} "{\"level1\": \"${expectedValue1}\"}") || fail "Failed to add document"
     id2=$(../fuego add ${TEST_COLLECTION} "{\"level1\": \"${expectedValue2}\"}") || fail "Failed to add document"
-    result=$(../fuego deleteall ${TEST_COLLECTION} ${id1},${id2} | jq -r '.[].level1'| tr '\n' ' ')
-    result=$(../fuego getall ${TEST_COLLECTION} ${id1},${id2} | jq -r '.[].level1'| tr '\n' ' ')
+    result=$(../fuego deleteall ${TEST_COLLECTION} ${id1} ${id2} | jq -r '.[].level1'| tr '\n' ' ')
+    result=$(../fuego getall ${TEST_COLLECTION} ${id1} ${id2} | jq -r '.[].level1'| tr '\n' ' ')
     assertEquals "Failed to read all added value" "" "${result}"
 }
 


### PR DESCRIPTION
To make it more "standard"/idiomatic.
 
```
fuego getall collection-id doc-1-id doc-2-id....
fuego deleteall collection-id doc-1-id doc-2-id....

```