### PR TITLE
Improves release cration process

### DIFF
--- a/.github/workflows/dev.workflow.yml
+++ b/.github/workflows/dev.workflow.yml
@@ -17,6 +17,15 @@ jobs:
           node-version: '14'
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Retrieve new version
+        run: |
+          echo "::set-output name=TAG_NAME::$(cat main.go|grep app.Version|grep -Eo '[0-9.]{2,100}')"
+        id: version
+      - name: "Check releases notes"
+        uses: andstor/file-existence-action@v1
+        allow_failure: true
+        with:
+          files: release-notes/${{ steps.version.outputs.TAG_NAME }}.md
       - uses: actions/cache@v2
         with:
           # In order:

--- a/.github/workflows/master.workflow.yml
+++ b/.github/workflows/master.workflow.yml
@@ -17,6 +17,15 @@ jobs:
           node-version: '14'
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Retrieve new version
+        run: |
+          echo "::set-output name=TAG_NAME::$(cat main.go|grep app.Version|grep -Eo '[0-9.]{2,100}')"
+        id: version
+      - name: "Check releases notes"
+        uses: andstor/file-existence-action@v1
+        allow_failure: true
+        with:
+          files: release-notes/${{ steps.version.outputs.TAG_NAME }}.md
       - uses: actions/cache@v2
         with:
           # In order:
@@ -68,6 +77,6 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist --release-notes=CHANGELOG.md
+          args: release --rm-dist --release-notes=release-notes/${{ steps.version.outputs.TAG_NAME }}.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.15.0]
+### Changed
+- Changes arguments for getall and deleteall commands.
+- Adds documentation for creating releases.
+
 ## [0.14.0]
 ### Changed
 - Add delete all operation

--- a/release-notes/0.15.0.md
+++ b/release-notes/0.15.0.md
@@ -1,0 +1,2 @@
+- Changes arguments for getall and deleteall commands: document id's should now
+  be separated by spaces instead of commas.


### PR DESCRIPTION
Instead of using the changelog as the release notes, goreleaser will now
use the file release-notes/(current version).md.

The current version is obtained from the main.go file. It is therefore
imperative that the version is updated before pushing anything to the
master branch.