### PR TITLE
Removes 'batch' option from query.

### DIFF
--- a/main.go
+++ b/main.go
@@ -177,11 +177,6 @@ func main() {
 					Name:  "select",
 					Usage: "Return only `FIELD_PATH` fields in result. Parameter can be given multiple times",
 				},
-				cli.IntFlag{
-					Name:  "batch, b",
-					Usage: "Will fetch documents in several requests with at most `BATCH` documents per request to prevent timeouts (currently 60s).",
-					Value: 1000,
-				},
 			},
 		},
 	}

--- a/tests/tests
+++ b/tests/tests
@@ -127,12 +127,12 @@ testQueryWithSelect(){
 }
 
 testGroupQuery() {
-		../fuego set ${TEST_COLLECTION}/doc1/${TEST_COLLECTION_2}/doc1_1 '{}'
-		../fuego set ${TEST_COLLECTION}/doc1/${TEST_COLLECTION_2}/doc1_2 '{}'
-		../fuego set ${TEST_COLLECTION}/doc2/${TEST_COLLECTION_2}/doc2_1 '{}'
-		../fuego set ${TEST_COLLECTION}/doc2/${TEST_COLLECTION_2}/doc2_2 '{}'
-		result=$(../fuego query -g ${TEST_COLLECTION_2} | jq '. | length')
-		assertEquals "Failed to query group collection" "4" "${result}"
+    ../fuego set ${TEST_COLLECTION}/doc1/${TEST_COLLECTION_2}/doc1_1 '{}'
+    ../fuego set ${TEST_COLLECTION}/doc1/${TEST_COLLECTION_2}/doc1_2 '{}'
+    ../fuego set ${TEST_COLLECTION}/doc2/${TEST_COLLECTION_2}/doc2_1 '{}'
+    ../fuego set ${TEST_COLLECTION}/doc2/${TEST_COLLECTION_2}/doc2_2 '{}'
+    result=$(../fuego query -g ${TEST_COLLECTION_2} | jq '. | length')
+    assertEquals "Failed to query group collection" "4" "${result}"
 }
 
 testQueryDifferentValueTypes(){
@@ -204,26 +204,6 @@ testCompoundQuery(){
     result=$(../fuego query ${TEST_COLLECTION} "key2 == 1" "key1 == \"key1\"")
     assertEquals "Failed to query on two keys" "" "$result"
 
-}
-
-testQueryBatched(){
-    # this unittest is testing several aspects to only need to create the bigger collection once (reduce test runtime)
-
-    # create 50 items in parallel
-    seq 50 | xargs -I@ -P 50 ../fuego add ${TEST_COLLECTION} '{"id": @}' > /dev/null
-
-    # make sure we receive exactly limit entries
-    result=$(../fuego query --limit 25 --batch 10 ${TEST_COLLECTION}  | jq "length" )
-    assertEquals "Failed to query in batches" "25" "$result"
-
-    # make sure we receive exactly limit entries
-    result=$(../fuego query --limit 100 --batch 200 ${TEST_COLLECTION}  | jq "length" )
-    assertEquals "Failed to query in batches" "50" "$result"
-
-    # make sure ordering is still working
-    # as we have the documents with id 1..50 the 15th item will have value 16
-    result=$(../fuego query --limit 20 --batch 5 --orderby id --orderdir ASC ${TEST_COLLECTION}  | jq -c ".[15].Data.id"  )
-    assertEquals "Failed to query in batches" "16" "$result"
 }
 
 


### PR DESCRIPTION
This option is no longer necessary since we are using the iterator
interface 'Next' interface instead of calling GetAll.