### PR TITLE
Implemented recursive delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,13 @@ fuego delete people/Rv7ZfnLQWprdXuulqMdf
 
 note: this won't delete any subcollection under the document.
 
+To delete a document including subcollections, use the ```--recursive, -r``` flag.
+Using the ```-r``` flag will also delete missing documents. A missing document is a 
+document that does not exist but has sub-documents.
+```sh
+fuego delete -r people/Rv7ZfnLQWprdXuulqMdf
+```
+
 It's also possible to delete multiple documents without transaction
 ```sh
 fuego delete people Rv7ZfnLQWprdXuulqMdf,Rv7ZfnLQWprdXuulqMde

--- a/main.go
+++ b/main.go
@@ -43,6 +43,13 @@ func main() {
 		},
 	}
 
+	deleteFlags := []cli.Flag{
+		cli.BoolFlag{
+			Name:  "recursive, r",
+			Usage: "Recursively delete sub-collections",
+		},
+	}
+
 	app.Commands = []cli.Command{
 		{
 			Name:    "collections",
@@ -123,6 +130,7 @@ func main() {
 			Usage:     "Delete a document from a collection",
 			ArgsUsage: "[collection-path document-id | document-path]",
 			Action:    deleteCommandAction,
+			Flags:     deleteFlags,
 		},
 		{
 			Name:      "deleteall",

--- a/tests/tests
+++ b/tests/tests
@@ -349,6 +349,32 @@ testCopyDocumentAndCollection(){
     assertEquals "Failed to copy document" "${expectedValue}" "${result}"
 }
 
+testDeleteRecursive(){
+      # adding new documents with nested sub-collections
+      id=$(../fuego add ${TEST_COLLECTION} "{\"base\": \"value\"}") || fail "Failed to add document"
+      subDocId1=$(../fuego add "${TEST_COLLECTION}/${id}/subCollection1" "{\"base\": \"sub value1\"}") || fail "Failed to add document"
+      subSubDocId1=$(../fuego add "${TEST_COLLECTION}/${id}/subCollection1/${subDocId1}/subSubCollection1" "{\"base\": \"subsub value1\"}")|| fail "Failed to add document"
 
+      subDocId2=$(../fuego add "${TEST_COLLECTION}/${id}/subCollection2" "{\"base\": \"sub value2\"}") || fail "Failed to add document"
+      subSubDocId2=$(../fuego add "${TEST_COLLECTION}/${id}/subCollection2/${subDocId2}/subSubCollection2" "{\"base\": \"subsub value2\"}")|| fail "Failed to add document"
+      echo ${id} ${subDocId1} ${subSubDocId1} ${subDocId2} ${subSubDocId2}
+
+      # delete one collection without recursive flag. To test deletion of missing documents.
+      ../fuego delete "${TEST_COLLECTION}/${id}/subCollection1" ${subDocId1}
+      assertFalse "Should not have read deleted value" "../fuego get ${TEST_COLLECTION}/${id}/subCollection1 ${subDocId1}"
+
+      # check that sub-collection of deleted collection still exists
+      expectedValue=$(echo "{\"base\": \"subsub value1\"}" | jq .)
+      result=$(../fuego get "${TEST_COLLECTION}/${id}/subCollection1/${subDocId1}/subSubCollection1/${subSubDocId1}"  | jq .Data)
+      assertEquals "Should be able to read SubCollection" "${result}" "${expectedValue}"
+
+      # call delete again, but with recursive flag.
+      ../fuego delete -r "${TEST_COLLECTION}" ${id}
+
+      # check that all documents are deleted, also the missing documents.
+      assertFalse "Should not have read deleted value2" "../fuego get ${TEST_COLLECTION}/${id}/subCollection1/${subDocId1}/subSubCollection1 ${subSubDocId1}"
+      assertFalse "Should not have read deleted value3" "../fuego get ${TEST_COLLECTION}/${id}/subCollection2 ${subDocId2}"
+      assertFalse "Should not have read deleted value2" "../fuego get ${TEST_COLLECTION}/${id}/subCollection2/${subDocId2}/subSubCollection2 ${subSubDocId2}"
+}
 # Load shUnit2.
 . ./shunit2


### PR DESCRIPTION
solves #59 

### Summary

Introduced `--recursive | -r` to the delete command. By using this flag, all sub-collections contained in the selected document will also be deleted,  including missing documents. A missing document is a document that does not exist but has sub-documents.

### Open Points
This flag should also be added to the `deleteall` command.